### PR TITLE
corrects formating to g_message of file size

### DIFF
--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -615,13 +615,13 @@ gboolean process_deployment(JsonNode *req_root, GError **error)
                 goto proc_error;
         }
 
-        g_message("New software ready for download. (Name: %s, Version: %s, Size: %ld, URL: %s)",
+        g_message("New software ready for download. (Name: %s, Version: %s, Size: %" G_GINT64_FORMAT ", URL: %s)",
                   artifact->name, artifact->version, artifact->size, artifact->download_url);
 
         // Check if there is enough free diskspace
         long freespace = get_available_space(hawkbit_config->bundle_download_location);
         if (freespace < artifact->size) {
-                g_autofree gchar *msg = g_strdup_printf("Not enough free space. File size: %ld. Free space: %ld",
+                g_autofree gchar *msg = g_strdup_printf("Not enough free space. File size: %" G_GINT64_FORMAT  ". Free space: %ld",
                                                         artifact->size, freespace);
                 g_debug("%s", msg);
                 // Notify hawkbit that there is not enough free space.


### PR DESCRIPTION
Problem is that the g_message call at hawkbit-client.c:618
is passing the file size as %ld in format. Must be %lld due
to the data type holding the file size. If this is not changed
the application will segfault in a strlen call in extension of
the g-message call.

Also the g_strdup_printf call at hawkbit-client.c:624 should
have the %ld changed to %lld.

Keeping the %ld entries also produces compiler warnings in GCC 8.2.0

Signed-off-by: Niklas Johansson <niklas.johansson@prevas.dk>